### PR TITLE
<fix> Normalise quotients to form a/b * c

### DIFF
--- a/pages/index/script.js
+++ b/pages/index/script.js
@@ -1,6 +1,6 @@
 // TODO: Eventually, put this in a separate file
 let RAW_SOLUTION = "1/2 x^2 sin(2x) + 1/2 x cos(2x) - 1/4 sin(2x) + c";
-let SOLUTION = strToTree(RAW_SOLUTION); // TODO: Add normaliseTree back
+let SOLUTION = normaliseTree(strToTree(RAW_SOLUTION)); // TODO: Add normaliseTree back
 let answerText = document.getElementById("answerText"); // Answer that appears on win modal
 answerText.innerText = `\\(${RAW_SOLUTION}\\)`;
 

--- a/pages/index/script.js
+++ b/pages/index/script.js
@@ -412,6 +412,53 @@ function normaliseTree(tree, rootNodeIndex=0)
 		currentNodeIndex = findNextInDFS(tree, 0, tree.Find(currentNode));
 	}
 
+	// Convert all quotients to form 1/b * a
+	currentNodeIndex = 0;
+	while (currentNodeIndex != -1)
+	{
+		let currentNode = tree[currentNodeIndex];
+		if (!checkDividendIsNot1(tree, currentNode))
+		{
+			currentNodeIndex = findNextInDFS(tree, 0, currentNodeIndex);
+			continue;
+		}
+
+		let a = tree[currentNode.rightNode];
+
+		// Add * node
+		let multiplyNode = {
+			content: '*',
+			type: "operator",
+			leftNode: tree.indexOf(a),
+			rightNode: currentNodeIndex,
+			parent: currentNode.parent,
+			depth: -1
+		};
+
+		tree.push(multiplyNode);
+
+		currentNode.parent = tree.indexOf(multiplyNode);
+		a.parent = tree.indexOf(multiplyNode);
+
+		// Add 1 node
+		let oneNode = {
+			content: '1',
+			type: "number",
+			leftNode: -1,
+			rightNode: -1,
+			parent: tree.indexOf(currentNode),
+			depth: -1
+		};
+
+		tree.push(oneNode);
+		currentNode.rightNode = tree.indexOf(oneNode);
+
+		// Change current node index to index of * (to traverse over a)
+		currentNodeIndex = tree.indexOf(multiplyNode);
+
+		currentNodeIndex = findNextInDFS(tree, 0, tree.indexOf(currentNode));
+	}
+
 	// Create a dictionary of depth:node indices
 	currentNodeIndex = tree.root;
 	for (let i = 0; i < tree.length; i++)
@@ -534,11 +581,26 @@ function checkDividendIsProduct(tree, node)
 	// Check if node is /, and right child is *
 	if (node.type != NodeType.OPERATOR || node.content != '/')
 		return false;
-	if (node.rightNode == -1)
-		return false;
 
 	let currentRightNode = tree.Get(node.rightNode);
 	if (currentRightNode.type != NodeType.OPERATOR || currentRightNode.content != '*')
+		return false;
+
+	return true;
+}
+
+// Checks whether current node is a /, and is dividend is something other than 1
+// Essentially, checks for divisions in the form of a/b (as these need to be normalised to 1/b * a)
+// INPUTS: tree, node in tree
+// RETURNS: bool true is dividend is not 1, false if it is
+function checkDividendIsNot1(tree, node)
+{
+	// Check if node is /, and right child is not 1
+	if (node.type != "operator" || node.content != '/')
+		return false;
+
+	let currentRightNode = tree[node.rightNode];
+	if (currentRightNode.type == "number" && currentRightNode.content == '1')
 		return false;
 
 	return true;

--- a/pages/index/script.js
+++ b/pages/index/script.js
@@ -412,7 +412,7 @@ function normaliseTree(tree, rootNodeIndex=0)
 		currentNodeIndex = findNextInDFS(tree, 0, tree.Find(currentNode));
 	}
 
-	// Convert all quotients to form 1/b * a
+// Convert all quotients to form 1/b * a
 	currentNodeIndex = 0;
 	while (currentNodeIndex != -1)
 	{
@@ -449,6 +449,13 @@ function normaliseTree(tree, rootNodeIndex=0)
 			// Fix children of /
 			let b = tree[currentNode.leftNode];
 			b.parent = tree.indexOf(currentNode);
+		}
+
+		// If not, make * the right node if its parent
+		else
+		{
+			let multiplyNodeParent = tree[currentNode.parent];
+			multiplyNodeParent.rightNode = tree.indexOf(multiplyNode);
 		}
 
 		currentNode.parent = tree.indexOf(multiplyNode);

--- a/pages/index/script.js
+++ b/pages/index/script.js
@@ -1,6 +1,6 @@
 // TODO: Eventually, put this in a separate file
 let RAW_SOLUTION = "1/2 x^2 sin(2x) + 1/2 x cos(2x) - 1/4 sin(2x) + c";
-let SOLUTION = normaliseTree(strToTree(RAW_SOLUTION));
+let SOLUTION = strToTree(RAW_SOLUTION); // TODO: Add normaliseTree back
 let answerText = document.getElementById("answerText"); // Answer that appears on win modal
 answerText.innerText = `\\(${RAW_SOLUTION}\\)`;
 
@@ -382,9 +382,40 @@ function postfixToTree(components, index=0, parentIndex=-1, depth=0)
 // RETURNS: list normalised tree
 function normaliseTree(tree, rootNodeIndex=0)
 {
-	let currentNodeIndex = rootNodeIndex;
+	// Convert all quotients to form a/b * c
+	let currentNodeIndex = 0;
 	while (currentNodeIndex != -1)
 	{
+		// Check quotient is in form ac/b, and needs to be transformed
+		// (Current node is /, and right child is *)
+		let currentNode = tree.Get(currentNodeIndex);
+		if (!checkDivisorIsProduct(tree, currentNode))
+		{
+			currentNodeIndex = findNextInDFS(tree, 0, currentNodeIndex);
+			continue;
+		}
+
+		// Make a (right child of *) the right child of /
+		let currentRightNode = tree.Get(currentNode.rightNode);
+		currentNode.rightNode = currentRightNode.rightNode;
+		let a = tree.Get(currentNode.rightNode);
+		a.parent = tree.Find(currentNode);
+
+		// Make / the right child of *
+		currentRightNode.rightNode = tree.Find(currentNode);
+		currentNode.parent = tree.Find(currentRightNode);
+
+		// TODO: If / is at front of list, we need to swap the / and * around.
+		currentNodeIndex = findNextInDFS(tree, 0, tree.Find(currentNode));
+	}
+
+	// Create a dictionary of depth:node indices
+	currentNodeIndex = tree.root;
+	console.log(tree);
+	for (let i = 0; i < tree.length; i++)
+	{
+		console.log(i);
+		console.log(currentNodeIndex);
 		let currentNode = tree.Get(currentNodeIndex);
 		// If commutative node found, add children to list
 		if (currentNode.type == NodeType.OPERATOR && currentNode.commutative == true)
@@ -492,6 +523,25 @@ function findCommutativeNodes(tree, opNodeIndex, operator)
 	}
 	return {"nodes": commutativeNodesList,
 		"parents": commutativeParentsList};
+}
+
+// Checks whether current node is a /, and if its dividend is a product.
+// Essentially, check for divisions in form of ab/c (as these need to be normalised to a/b * c)
+// INPUTS: tree, node in tree
+// RETURNS: bool true if divisor is product, false if not
+function checkDivisorIsProduct(tree, node)
+{
+	// Check if node is /, and right child is *
+	if (node.type != NodeType.OPERATOR || node.content != '/')
+		return false;
+	if (node.rightNode == -1)
+		return false;
+
+	let currentRightNode = tree.Get(node.rightNode);
+	if (currentRightNode.type != NodeType.OPERATOR || currentRightNode.content != '*')
+		return false;
+
+	return true;
 }
 
 // Compares 2 binary trees, and returns true if their contents are equal.

--- a/pages/index/script.js
+++ b/pages/index/script.js
@@ -397,6 +397,9 @@ function normaliseTree(tree, rootNodeIndex=0)
 
 		// Make a (right child of *) the right child of /
 		let currentRightNode = tree.Get(currentNode.rightNode);
+
+		// If / is root node, make * root node
+		tree.root = tree.Find(currentRightNode);
 		currentNode.rightNode = currentRightNode.rightNode;
 		let a = tree.Get(currentNode.rightNode);
 		a.parent = tree.Find(currentNode);
@@ -411,11 +414,8 @@ function normaliseTree(tree, rootNodeIndex=0)
 
 	// Create a dictionary of depth:node indices
 	currentNodeIndex = tree.root;
-	console.log(tree);
 	for (let i = 0; i < tree.length; i++)
 	{
-		console.log(i);
-		console.log(currentNodeIndex);
 		let currentNode = tree.Get(currentNodeIndex);
 		// If commutative node found, add children to list
 		if (currentNode.type == NodeType.OPERATOR && currentNode.commutative == true)

--- a/pages/index/script.js
+++ b/pages/index/script.js
@@ -416,73 +416,48 @@ function normaliseTree(tree, rootNodeIndex=0)
 	currentNodeIndex = 0;
 	while (currentNodeIndex != -1)
 	{
-		let currentNode = tree[currentNodeIndex];
+		let currentNode = tree.Get(currentNodeIndex);
 		if (!checkDividendIsNot1(tree, currentNode))
 		{
 			currentNodeIndex = findNextInDFS(tree, 0, currentNodeIndex);
 			continue;
 		}
 
-		let a = tree[currentNode.rightNode];
+		let a = tree.Get(currentNode.rightNode);
 
 		// Add * node
-		let multiplyNode = {
-			content: '*',
-			type: "operator",
-			leftNode: tree.indexOf(a),
-			rightNode: currentNodeIndex,
-			parent: currentNode.parent,
-			depth: -1
-		};
-
-		tree.push(multiplyNode);
+		let multiplyNode = new Node("operator", Operator.MULTIPLICATION, leftNode=tree.Find(a), rightNode=currentNodeIndex);
 
 		// If / is at front of list, we need to swap the / and * around.
-		if (currentNodeIndex == 0)
+		if (tree.Find(currentNode) == tree.root)
 		{
-			let temp = multiplyNode;
-			tree[tree.indexOf(multiplyNode)] = currentNode;
-			tree[0] = temp;
-
-			multiplyNode.parent = -1;
-			multiplyNode.rightNode = tree.indexOf(currentNode);
-			// Fix children of /
-			let b = tree[currentNode.leftNode];
-			b.parent = tree.indexOf(currentNode);
+			tree.AddAsRoot(multiplyNode);
 		}
-
 		// If not, make * the right node if its parent
 		else
 		{
-			let multiplyNodeParent = tree[currentNode.parent];
-			multiplyNodeParent.rightNode = tree.indexOf(multiplyNode);
+			let multiplyNodeParent = tree.Get(currentNode.parent);
+			multiplyNodeParent.rightNode = -1;
+			tree.Add(multiplyNode, multiplyNodeParent);
 		}
 
-		currentNode.parent = tree.indexOf(multiplyNode);
-		a.parent = tree.indexOf(multiplyNode);
+		currentNode.parent = tree.Find(multiplyNode);
+		a.parent = tree.Find(multiplyNode);
 
 		// Add 1 node
-		let oneNode = {
-			content: '1',
-			type: "number",
-			leftNode: -1,
-			rightNode: -1,
-			parent: tree.indexOf(currentNode),
-			depth: -1
-		};
+		let oneNode = newNode("number", '1');
+		tree.Add(oneNode, currentNode);
 
-		tree.push(oneNode);
-		currentNode.rightNode = tree.indexOf(oneNode);
+		currentNode.rightNode = tree.Find(oneNode);
 
 		// Change current node index to index of * (to traverse over a)
-		currentNodeIndex = tree.indexOf(multiplyNode);
+		currentNodeIndex = tree.Find(multiplyNode);
 
-		currentNodeIndex = findNextInDFS(tree, 0, tree.indexOf(currentNode));
+		currentNodeIndex = findNextInDFS(tree, 0, tree.Find(currentNode));
 	}
 
-	// Create a dictionary of depth:node indices
 	currentNodeIndex = tree.root;
-	for (let i = 0; i < tree.length; i++)
+	while (currentNodeIndex != -1)
 	{
 		let currentNode = tree.Get(currentNodeIndex);
 		// If commutative node found, add children to list
@@ -617,11 +592,11 @@ function checkDividendIsProduct(tree, node)
 function checkDividendIsNot1(tree, node)
 {
 	// Check if node is /, and right child is not 1
-	if (node.type != "operator" || node.content != '/')
+	if (node.type != NodeType.OPERATOR || node.content != '/')
 		return false;
 
-	let currentRightNode = tree[node.rightNode];
-	if (currentRightNode.type == "number" && currentRightNode.content == '1')
+	let currentRightNode = tree.Get(node.rightNode);
+	if (currentRightNode.type == NodeType.NUMBER && currentRightNode.content == '1')
 		return false;
 
 	return true;

--- a/pages/index/script.js
+++ b/pages/index/script.js
@@ -395,21 +395,40 @@ function normaliseTree(tree, rootNodeIndex=0)
 			continue;
 		}
 
+		let divisionNode = currentNode;
 		// Make a (right child of *) the right child of /
-		let currentRightNode = tree.Get(currentNode.rightNode);
+		let multiplicationNode = tree.Get(divisionNode.rightNode);
 
-		// If / is root node, make * root node
-		tree.root = tree.Find(currentRightNode);
-		currentNode.rightNode = currentRightNode.rightNode;
-		let a = tree.Get(currentNode.rightNode);
-		a.parent = tree.Find(currentNode);
+		// If / is root node, we need to make * root node
+		if (tree.Find(currentNode) == tree.root)
+		{
+			tree.root = tree.Find(multiplyNode);
+		}
+
+		// If not, make * the child of /'s parent 
+		else
+		{
+			let divisionNodeParent = tree.Get(divisionNode.parent);
+			if (divisionNodeParent.leftNode == tree.Find(divisionNode))
+			{
+				divisionNodeParent.leftNode = tree.Find(multiplicationNode);
+			}
+			else if (divisionNodeParent.rightNode == tree.Find(divisionNode))
+			{
+				divisionNodeParent.rightNode = tree.Find(multiplicationNode);
+			}
+		}
+
+		divisionNode.rightNode = multiplicationNode.rightNode;
+		let a = tree.Get(divisionNode.rightNode);
+		a.parent = tree.Find(divisionNode);
 
 		// Make / the right child of *
-		currentRightNode.rightNode = tree.Find(currentNode);
-		currentNode.parent = tree.Find(currentRightNode);
+		multiplicationNode.rightNode = tree.Find(divisionNode);
+		divisionNode.parent = tree.Find(multiplicationNode);
 
 		// TODO: If / is at front of list, we need to swap the / and * around.
-		currentNodeIndex = findNextInDFS(tree, 0, tree.Find(currentNode));
+		currentNodeIndex = findNextInDFS(tree, 0, tree.Find(divisionNode));
 	}
 
 // Convert all quotients to form 1/b * a
@@ -428,7 +447,7 @@ function normaliseTree(tree, rootNodeIndex=0)
 		// Add * node
 		let multiplyNode = new Node("operator", Operator.MULTIPLICATION, leftNode=tree.Find(a), rightNode=currentNodeIndex);
 
-		// If / is at front of list, we need to swap the / and * around.
+		// If / is root node, we need to make * root node
 		if (tree.Find(currentNode) == tree.root)
 		{
 			tree.AddAsRoot(multiplyNode);

--- a/pages/index/script.js
+++ b/pages/index/script.js
@@ -437,6 +437,20 @@ function normaliseTree(tree, rootNodeIndex=0)
 
 		tree.push(multiplyNode);
 
+		// If / is at front of list, we need to swap the / and * around.
+		if (currentNodeIndex == 0)
+		{
+			let temp = multiplyNode;
+			tree[tree.indexOf(multiplyNode)] = currentNode;
+			tree[0] = temp;
+
+			multiplyNode.parent = -1;
+			multiplyNode.rightNode = tree.indexOf(currentNode);
+			// Fix children of /
+			let b = tree[currentNode.leftNode];
+			b.parent = tree.indexOf(currentNode);
+		}
+
 		currentNode.parent = tree.indexOf(multiplyNode);
 		a.parent = tree.indexOf(multiplyNode);
 

--- a/pages/index/script.js
+++ b/pages/index/script.js
@@ -433,7 +433,8 @@ function normaliseTree(tree, rootNodeIndex=0)
 		{
 			tree.AddAsRoot(multiplyNode);
 		}
-		// If not, make * the right node if its parent
+
+		// If not, make * the right node of its parent
 		else
 		{
 			let multiplyNodeParent = tree.Get(currentNode.parent);

--- a/pages/index/script.js
+++ b/pages/index/script.js
@@ -389,7 +389,7 @@ function normaliseTree(tree, rootNodeIndex=0)
 		// Check quotient is in form ac/b, and needs to be transformed
 		// (Current node is /, and right child is *)
 		let currentNode = tree.Get(currentNodeIndex);
-		if (!checkDivisorIsProduct(tree, currentNode))
+		if (!checkDividendIsProduct(tree, currentNode))
 		{
 			currentNodeIndex = findNextInDFS(tree, 0, currentNodeIndex);
 			continue;
@@ -528,8 +528,8 @@ function findCommutativeNodes(tree, opNodeIndex, operator)
 // Checks whether current node is a /, and if its dividend is a product.
 // Essentially, check for divisions in form of ab/c (as these need to be normalised to a/b * c)
 // INPUTS: tree, node in tree
-// RETURNS: bool true if divisor is product, false if not
-function checkDivisorIsProduct(tree, node)
+// RETURNS: bool true if dividend is product, false if not
+function checkDividendIsProduct(tree, node)
 {
 	// Check if node is /, and right child is *
 	if (node.type != NodeType.OPERATOR || node.content != '/')

--- a/pages/index/tree.js
+++ b/pages/index/tree.js
@@ -255,6 +255,15 @@ class Tree {
 		this.#_body.push(node);
 		return;
 	}
+	
+	// Add a node to the tree as the root node. Note: The previous root node will need its parent node to be assigned separately.
+	// INPUTS: Node to add as root
+	// RETURNS: none.
+	AddAsRoot(node) {
+		this.#_body.push(node);
+		this.root = this.Find(node);
+		return;
+	}
 
 	// Remove a specified node from the graph.
 	// INPUTS: Node to remove


### PR DESCRIPTION
Quotients of form ac/b and a/b * c have differing expression trees (see attached image).
So do a/b and 1/b * a.
Essentially, this change adds a pass that converts all expressions of the form ac/b -> 1/b  * a * c
<img width="1508" height="504" alt="image" src="https://github.com/user-attachments/assets/3653da00-8fcb-4c1c-9182-4233e56b1b51" />